### PR TITLE
fix(tests): make github-review base_sha test self-contained (#5)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,12 +63,7 @@ jobs:
           COLUMNS: '200'
         run: |
           cd backend
-          # Deselected: test_github_review_output assumes a specific
-          # git history layout that's brittle in CI checkouts (resolves
-          # commits that don't exist in the runner's clone). Tracked
-          # as a follow-up to harden the test fixture.
-          pytest --cov=securescan --cov-fail-under=77 tests/ \
-            --deselect tests/test_github_review_output.py::test_github_review_resolves_base_sha_from_base_ref_in_diff_ref_mode
+          pytest --cov=securescan --cov-fail-under=77 tests/
       - name: pip-audit
         # pip-audit on PRs catches CVE-bumped deps immediately instead of
         # waiting for the weekly cron in securescan.yml. continue-on-error

--- a/backend/tests/test_baseline_cmd.py
+++ b/backend/tests/test_baseline_cmd.py
@@ -90,7 +90,7 @@ def test_baseline_command_registered():
 
     opts: set[str] = set()
     for param in baseline_cmd.params:
-        if isinstance(param, click.Option):
+        if getattr(param, "param_type_name", None) == "option":
             opts.update(param.opts)
     assert "--output-file" in opts
     assert "--no-ai" in opts

--- a/backend/tests/test_baseline_cmd.py
+++ b/backend/tests/test_baseline_cmd.py
@@ -81,7 +81,6 @@ def test_baseline_command_registered():
     flags. Uses Click's command introspection (durable across terminal
     widths and rendering changes) instead of asserting on help-text
     output."""
-    import click
     from typer.main import get_command
 
     cli = get_command(app)

--- a/backend/tests/test_cli_ci.py
+++ b/backend/tests/test_cli_ci.py
@@ -29,7 +29,7 @@ def _scan_options() -> set[str]:
     scan = cli.commands["scan"]  # type: ignore[union-attr]
     opts: set[str] = set()
     for param in scan.params:
-        if isinstance(param, click.Option):
+        if getattr(param, "param_type_name", None) == "option":
             opts.update(param.opts)  # both long and short forms
     return opts
 

--- a/backend/tests/test_cli_ci.py
+++ b/backend/tests/test_cli_ci.py
@@ -15,7 +15,6 @@ that's the actual contract we care about: are the flags wired up?
 
 from __future__ import annotations
 
-import click
 from typer.main import get_command
 from typer.testing import CliRunner
 

--- a/backend/tests/test_cli_init.py
+++ b/backend/tests/test_cli_init.py
@@ -343,7 +343,7 @@ def test_init_command_registered():
 
     opts: set[str] = set()
     for param in init_cmd.params:
-        if isinstance(param, click.Option):
+        if getattr(param, "param_type_name", None) == "option":
             opts.update(param.opts)
     for expected in (
         "--force",

--- a/backend/tests/test_cli_init.py
+++ b/backend/tests/test_cli_init.py
@@ -334,7 +334,6 @@ def test_scan_types_flag_rejects_unknown(tmp_path):
 
 def test_init_command_registered():
     """Verify ``init`` is on the root Typer app with the expected flags."""
-    import click
     from typer.main import get_command
 
     cli = get_command(app)

--- a/backend/tests/test_cli_staged.py
+++ b/backend/tests/test_cli_staged.py
@@ -21,7 +21,6 @@ import sys
 from pathlib import Path
 from unittest import mock
 
-import click
 import pytest
 import tomllib
 import typer

--- a/backend/tests/test_cli_staged.py
+++ b/backend/tests/test_cli_staged.py
@@ -92,7 +92,7 @@ def test_staged_flag_registered_on_scan_command():
     scan_cmd = cli.commands["scan"]  # type: ignore[union-attr]
     opts: set[str] = set()
     for param in scan_cmd.params:
-        if isinstance(param, click.Option):
+        if getattr(param, "param_type_name", None) == "option":
             opts.update(param.opts)
     assert "--staged" in opts
 

--- a/backend/tests/test_diff_cmd.py
+++ b/backend/tests/test_diff_cmd.py
@@ -49,7 +49,6 @@ def test_diff_command_registered_in_cli():
     """Verify the diff subcommand is registered with the expected flags.
     Uses Click's command introspection rather than asserting on rendered
     help output (which collapses without a TTY in CI)."""
-    import click
     from typer.main import get_command
 
     cli = get_command(app)

--- a/backend/tests/test_diff_cmd.py
+++ b/backend/tests/test_diff_cmd.py
@@ -58,7 +58,7 @@ def test_diff_command_registered_in_cli():
 
     opts: set[str] = set()
     for param in diff_cmd.params:
-        if isinstance(param, click.Option):
+        if getattr(param, "param_type_name", None) == "option":
             opts.update(param.opts)
     assert "--base-ref" in opts
     assert "--base-snapshot" in opts

--- a/backend/tests/test_github_review_output.py
+++ b/backend/tests/test_github_review_output.py
@@ -697,7 +697,7 @@ def test_github_review_resolves_base_sha_from_base_ref_in_diff(tmp_path):
     subprocess.run(["git", "--version"], capture_output=True).returncode != 0,
     reason="git not available on this host",
 )
-def test_github_review_resolves_base_sha_from_base_ref_in_diff_ref_mode(tmp_path):
+def test_github_review_resolves_base_sha_from_base_ref_in_diff_ref_mode(tmp_path, monkeypatch):
     """The proper ref-mode path: ``--base-ref main`` should auto-set
     ``base_sha`` from the live repo via ``git rev-parse``.
 
@@ -713,10 +713,16 @@ def test_github_review_resolves_base_sha_from_base_ref_in_diff_ref_mode(tmp_path
     head_sha = _git(["rev-parse", "HEAD"], cwd=repo)
 
     runner = CliRunner()
-    env = {
-        **os.environ,
-        "SECURESCAN_FAKE_NOW": "2026-01-01T00:00:00",
-    }
+    # Strip GITHUB_* envvars so the runner's own checkout (e.g.
+    # GITHUB_SHA on a GH-hosted runner, which is wired up to --sha
+    # via Typer's envvar=) cannot leak in and shadow the per-test
+    # tmp_path fixture's shas. Without this, --sha resolves to the
+    # runner's commit, which doesn't exist in the tmp_path repo, and
+    # `git diff base..sha` fails with "bad object <head-sha>".
+    for key in list(os.environ):
+        if key.startswith("GITHUB_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("SECURESCAN_FAKE_NOW", "2026-01-01T00:00:00")
     result = runner.invoke(
         app,
         [
@@ -732,7 +738,6 @@ def test_github_review_resolves_base_sha_from_base_ref_in_diff_ref_mode(tmp_path
             "Metbcy/securescan",
             "--no-ai",
         ],
-        env=env,
     )
     assert result.exit_code == 0, (result.stderr, result.stdout)
     payload = json.loads(result.stdout)

--- a/backend/tests/test_suppressed_rendering.py
+++ b/backend/tests/test_suppressed_rendering.py
@@ -922,7 +922,6 @@ def test_scan_command_accepts_no_suppress_flag(monkeypatch):
 def test_diff_command_help_lists_new_flags():
     """Verify diff registers --show-suppressed and --no-suppress.
     Uses Click introspection rather than asserting on rendered help."""
-    import click
     from typer.main import get_command
 
     cli = get_command(app)
@@ -937,7 +936,6 @@ def test_diff_command_help_lists_new_flags():
 
 def test_compare_command_help_lists_new_flags():
     """Verify compare registers --show-suppressed and --no-suppress."""
-    import click
     from typer.main import get_command
 
     cli = get_command(app)

--- a/backend/tests/test_suppressed_rendering.py
+++ b/backend/tests/test_suppressed_rendering.py
@@ -929,7 +929,7 @@ def test_diff_command_help_lists_new_flags():
     diff_cmd = cli.commands["diff"]  # type: ignore[union-attr]
     opts: set[str] = set()
     for param in diff_cmd.params:
-        if isinstance(param, click.Option):
+        if getattr(param, "param_type_name", None) == "option":
             opts.update(param.opts)
     assert "--show-suppressed" in opts
     assert "--no-suppress" in opts
@@ -944,7 +944,7 @@ def test_compare_command_help_lists_new_flags():
     compare_cmd = cli.commands["compare"]  # type: ignore[union-attr]
     opts: set[str] = set()
     for param in compare_cmd.params:
-        if isinstance(param, click.Option):
+        if getattr(param, "param_type_name", None) == "option":
             opts.update(param.opts)
     assert "--show-suppressed" in opts
     assert "--no-suppress" in opts


### PR DESCRIPTION
Closes #5.

## What

Re-enables `test_github_review_resolves_base_sha_from_base_ref_in_diff_ref_mode` in CI by making the test self-contained.

## Root cause

The test seeds a fresh git repo in `tmp_path` with two commits, then invokes `securescan diff --base-ref HEAD~1 ...` against it. But `CliRunner.invoke` was being passed the full parent `os.environ`. On GitHub-hosted runners that environment includes `GITHUB_SHA`, which Typer maps to `--sha` via `envvar=` in the command spec. The runner's commit sha then shadows the fixture's head sha, and `git diff base..<runner-sha>` against the tmp_path repo fails with `fatal: bad object <head-sha>`.

Locally the test passed because no `GITHUB_*` vars are set.

## Fix

Strip `GITHUB_*` env vars via `monkeypatch.delenv` before invoking the CLI, so the fixture is fully self-contained. Drop the `--deselect` line in `lint.yml`.

## Verification

`pytest backend/tests/test_github_review_output.py` passes locally with `GITHUB_SHA=fake GITHUB_BASE_REF=main GITHUB_REPOSITORY=foo/bar` exported to confirm the fix actually addresses the runner-env leak (not just the unset-locally case).

## Acceptance criteria
- [x] `--deselect` removed from `.github/workflows/lint.yml`
- [x] Test runs in self-contained git fixture (was already doing this; the env leak was the bug)
- [x] Local `pytest` passes
- [x] CI `pytest` passes the test without `--deselect` (will be confirmed by this PR's CI run)
