### PR TITLE
feat(scanning): scheduled scans (cron-like) (#7)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "PyYAML>=6.0",
     "python-dotenv>=1.0.0",
     "redis>=5.0.0",
+    "apscheduler>=3.10.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/securescan/api/schedules.py
+++ b/backend/securescan/api/schedules.py
@@ -1,0 +1,178 @@
+"""CRUD endpoints for cron-driven scan schedules (FEAT-SCHEDULES).
+
+Endpoints
+---------
+* ``POST   /api/schedules``         - admin: create a new schedule.
+* ``GET    /api/schedules``         - admin: list all schedules.
+* ``GET    /api/schedules/{id}``    - admin: fetch one schedule.
+* ``PATCH  /api/schedules/{id}``    - admin: edit fields.
+* ``DELETE /api/schedules/{id}``    - admin: delete and cascade run history.
+* ``GET    /api/schedules/{id}/runs`` - admin: last 50 run rows.
+
+All endpoints require the ``admin`` scope.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from apscheduler.triggers.cron import CronTrigger
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, field_validator
+
+from ..auth import require_scope
+from ..database import (
+    delete_schedule,
+    get_schedule,
+    insert_schedule,
+    list_schedule_runs,
+    list_schedules,
+    update_schedule,
+)
+from ..models import ScanType, Schedule, ScheduleRun
+from ..scheduler import scheduler as _scheduler
+
+router = APIRouter(prefix="/api/schedules", tags=["schedules"])
+
+
+def _validate_cron(expr: str) -> str:
+    """Reject expressions that APScheduler cannot parse."""
+    try:
+        CronTrigger.from_crontab(expr)
+    except Exception as exc:
+        raise ValueError(f"invalid cron expression: {exc}") from exc
+    return expr
+
+
+class CreateScheduleBody(BaseModel):
+    name: str = Field(min_length=1, max_length=200)
+    target_path: str = Field(min_length=1)
+    scan_types: list[ScanType] = Field(
+        default_factory=lambda: [ScanType.CODE, ScanType.DEPENDENCY], min_length=1
+    )
+    cron_expression: str
+
+    @field_validator("cron_expression")
+    @classmethod
+    def _check_cron(cls, v: str) -> str:
+        try:
+            return _validate_cron(v)
+        except ValueError as exc:
+            raise ValueError(str(exc)) from exc
+
+
+class PatchScheduleBody(BaseModel):
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    target_path: str | None = Field(default=None, min_length=1)
+    scan_types: list[ScanType] | None = Field(default=None, min_length=1)
+    cron_expression: str | None = None
+    enabled: bool | None = None
+
+    @field_validator("cron_expression")
+    @classmethod
+    def _check_cron(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        try:
+            return _validate_cron(v)
+        except ValueError as exc:
+            raise ValueError(str(exc)) from exc
+
+
+@router.post(
+    "",
+    response_model=Schedule,
+    status_code=201,
+    dependencies=[Depends(require_scope("admin"))],
+)
+async def create_schedule(body: CreateScheduleBody) -> Schedule:
+    """Create a new cron schedule. Immediately registers a live APScheduler job."""
+    schedule_id = str(uuid.uuid4())
+    created_at = datetime.utcnow()
+    await insert_schedule(
+        id=schedule_id,
+        name=body.name,
+        target_path=body.target_path,
+        scan_types=[t.value for t in body.scan_types],
+        cron_expression=body.cron_expression,
+        enabled=True,
+        created_at=created_at,
+    )
+    _scheduler.add(schedule_id, body.cron_expression)
+    sched = await get_schedule(schedule_id)
+    if sched is None:
+        raise HTTPException(500, "Failed to retrieve created schedule")
+    return sched
+
+
+@router.get(
+    "",
+    response_model=list[Schedule],
+    dependencies=[Depends(require_scope("admin"))],
+)
+async def get_schedules() -> list[Schedule]:
+    """List all schedules, newest first."""
+    return await list_schedules()
+
+
+@router.get(
+    "/{schedule_id}",
+    response_model=Schedule,
+    dependencies=[Depends(require_scope("admin"))],
+)
+async def get_schedule_endpoint(schedule_id: str) -> Schedule:
+    sched = await get_schedule(schedule_id)
+    if sched is None:
+        raise HTTPException(404, "Schedule not found")
+    return sched
+
+
+@router.patch(
+    "/{schedule_id}",
+    response_model=Schedule,
+    dependencies=[Depends(require_scope("admin"))],
+)
+async def patch_schedule(schedule_id: str, body: PatchScheduleBody) -> Schedule:
+    """Edit any subset of fields. Keeps the live scheduler in sync."""
+    sched = await update_schedule(
+        schedule_id,
+        name=body.name,
+        target_path=body.target_path,
+        scan_types=[t.value for t in body.scan_types] if body.scan_types is not None else None,
+        cron_expression=body.cron_expression,
+        enabled=body.enabled,
+    )
+    if sched is None:
+        raise HTTPException(404, "Schedule not found")
+
+    new_cron = sched.cron_expression
+    new_enabled = sched.enabled
+    _scheduler.reschedule(schedule_id, new_cron, enabled=new_enabled)
+    return sched
+
+
+@router.delete(
+    "/{schedule_id}",
+    status_code=204,
+    dependencies=[Depends(require_scope("admin"))],
+)
+async def delete_schedule_endpoint(schedule_id: str) -> None:
+    """Delete a schedule and cascade-drop all run history."""
+    deleted = await delete_schedule(schedule_id)
+    if not deleted:
+        raise HTTPException(404, "Schedule not found")
+    _scheduler.remove(schedule_id)
+
+
+@router.get(
+    "/{schedule_id}/runs",
+    response_model=list[ScheduleRun],
+    dependencies=[Depends(require_scope("admin"))],
+)
+async def get_schedule_runs(schedule_id: str) -> list[ScheduleRun]:
+    """Last 50 run records for this schedule, newest first."""
+    sched = await get_schedule(schedule_id)
+    if sched is None:
+        raise HTTPException(404, "Schedule not found")
+    return await list_schedule_runs(schedule_id, limit=50)

--- a/backend/securescan/database.py
+++ b/backend/securescan/database.py
@@ -21,6 +21,8 @@ from .models import (
     ScanStatus,
     ScanSummary,
     ScanType,
+    Schedule,
+    ScheduleRun,
     Severity,
     TriageStatus,
     Webhook,
@@ -1368,5 +1370,190 @@ async def reset_stale_delivering_deliveries() -> int:
         )
         await db.commit()
         return cursor.rowcount
+    finally:
+        await db.close()
+
+
+# ---------------------------------------------------------------------------
+# Schedules (FEAT-SCHEDULES)
+# ---------------------------------------------------------------------------
+
+
+def _row_to_schedule(row: aiosqlite.Row) -> Schedule:
+    return Schedule(
+        id=row["id"],
+        name=row["name"],
+        target_path=row["target_path"],
+        scan_types=[ScanType(t) for t in json.loads(row["scan_types"])],
+        cron_expression=row["cron_expression"],
+        last_run=datetime.fromisoformat(row["last_run"]) if row["last_run"] else None,
+        enabled=bool(row["enabled"]),
+        created_at=datetime.fromisoformat(row["created_at"]),
+    )
+
+
+async def insert_schedule(
+    *,
+    id: str,
+    name: str,
+    target_path: str,
+    scan_types: list[str],
+    cron_expression: str,
+    enabled: bool,
+    created_at: datetime,
+) -> None:
+    db = await _get_db()
+    try:
+        await db.execute(
+            """INSERT INTO schedules
+               (id, name, target_path, scan_types, cron_expression, enabled, created_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                id,
+                name,
+                target_path,
+                json.dumps(scan_types),
+                cron_expression,
+                1 if enabled else 0,
+                created_at.isoformat(),
+            ),
+        )
+        await db.commit()
+    finally:
+        await db.close()
+
+
+async def get_schedule(schedule_id: str) -> Schedule | None:
+    db = await _get_db()
+    try:
+        cursor = await db.execute("SELECT * FROM schedules WHERE id = ?", (schedule_id,))
+        row = await cursor.fetchone()
+        return _row_to_schedule(row) if row else None
+    finally:
+        await db.close()
+
+
+async def list_schedules(*, only_enabled: bool = False) -> list[Schedule]:
+    db = await _get_db()
+    try:
+        if only_enabled:
+            cursor = await db.execute(
+                "SELECT * FROM schedules WHERE enabled = 1 ORDER BY created_at DESC"
+            )
+        else:
+            cursor = await db.execute("SELECT * FROM schedules ORDER BY created_at DESC")
+        rows = await cursor.fetchall()
+        return [_row_to_schedule(r) for r in rows]
+    finally:
+        await db.close()
+
+
+async def update_schedule(
+    schedule_id: str,
+    *,
+    name: str | None = None,
+    target_path: str | None = None,
+    scan_types: list[str] | None = None,
+    cron_expression: str | None = None,
+    enabled: bool | None = None,
+) -> Schedule | None:
+    sets: list[str] = []
+    params: list = []
+    if name is not None:
+        sets.append("name = ?")
+        params.append(name)
+    if target_path is not None:
+        sets.append("target_path = ?")
+        params.append(target_path)
+    if scan_types is not None:
+        sets.append("scan_types = ?")
+        params.append(json.dumps(scan_types))
+    if cron_expression is not None:
+        sets.append("cron_expression = ?")
+        params.append(cron_expression)
+    if enabled is not None:
+        sets.append("enabled = ?")
+        params.append(1 if enabled else 0)
+    if not sets:
+        return await get_schedule(schedule_id)
+    params.append(schedule_id)
+    db = await _get_db()
+    try:
+        # nosemgrep: python.sqlalchemy.security.sqlalchemy-execute-raw-query.sqlalchemy-execute-raw-query
+        cursor = await db.execute(
+            f"UPDATE schedules SET {', '.join(sets)} WHERE id = ?",  # nosec B608 -- sets is literal column names only
+            params,
+        )
+        await db.commit()
+        if cursor.rowcount == 0:
+            return None
+    finally:
+        await db.close()
+    return await get_schedule(schedule_id)
+
+
+async def delete_schedule(schedule_id: str) -> bool:
+    db = await _get_db()
+    try:
+        cursor = await db.execute("SELECT 1 FROM schedules WHERE id = ?", (schedule_id,))
+        existed = await cursor.fetchone() is not None
+        if not existed:
+            return False
+        await db.execute("DELETE FROM schedule_runs WHERE schedule_id = ?", (schedule_id,))
+        await db.execute("DELETE FROM schedules WHERE id = ?", (schedule_id,))
+        await db.commit()
+        return True
+    finally:
+        await db.close()
+
+
+async def touch_schedule_last_run(schedule_id: str, last_run: datetime) -> None:
+    db = await _get_db()
+    try:
+        await db.execute(
+            "UPDATE schedules SET last_run = ? WHERE id = ?",
+            (last_run.isoformat(), schedule_id),
+        )
+        await db.commit()
+    finally:
+        await db.close()
+
+
+async def insert_schedule_run(
+    *,
+    id: str,
+    schedule_id: str,
+    scan_id: str | None,
+    triggered_at: datetime,
+) -> None:
+    db = await _get_db()
+    try:
+        await db.execute(
+            "INSERT INTO schedule_runs (id, schedule_id, scan_id, triggered_at) "
+            "VALUES (?, ?, ?, ?)",
+            (id, schedule_id, scan_id, triggered_at.isoformat()),
+        )
+        await db.commit()
+    finally:
+        await db.close()
+
+
+async def list_schedule_runs(schedule_id: str, *, limit: int = 50) -> list[ScheduleRun]:
+    db = await _get_db()
+    try:
+        cursor = await db.execute(
+            "SELECT * FROM schedule_runs WHERE schedule_id = ? ORDER BY triggered_at DESC LIMIT ?",
+            (schedule_id, limit),
+        )
+        rows = await cursor.fetchall()
+        return [
+            ScheduleRun(
+                id=r["id"],
+                schedule_id=r["schedule_id"],
+                scan_id=r["scan_id"],
+                triggered_at=datetime.fromisoformat(r["triggered_at"]),
+            )
+            for r in rows
+        ]
     finally:
         await db.close()

--- a/backend/securescan/main.py
+++ b/backend/securescan/main.py
@@ -19,6 +19,7 @@ from .api.keys import router as keys_router
 from .api.notifications import router as notifications_router
 from .api.sbom import router as sbom_router
 from .api.scans import router as scans_router
+from .api.schedules import router as schedules_router
 from .api.triage import router as triage_router
 from .api.versioning import alias_router_at_v1
 from .api.webhooks import router as webhooks_router
@@ -32,6 +33,7 @@ from .auth import (
 )
 from .database import count_admin_keys_active, init_db, prune_old_notifications
 from .middleware.rate_limit import RateLimitMiddleware
+from .scheduler import scheduler as scan_scheduler
 from .webhook_dispatcher import dispatcher as webhook_dispatcher
 
 _auth = [Depends(require_api_key)]
@@ -53,6 +55,7 @@ for _r in (
     keys_router,
     notifications_router,
     webhooks_router,
+    schedules_router,
 ):
     app.include_router(_r, dependencies=_auth)
     # Parallel /api/v1/* mount — the preferred path going forward. Same
@@ -134,6 +137,15 @@ async def _startup_webhook_dispatcher():
         _logger.exception("webhook dispatcher failed to start")
 
 
+@app.on_event("startup")
+async def _startup_scan_scheduler():
+    """Boot the cron-based scan scheduler (FEAT-SCHEDULES)."""
+    try:
+        await scan_scheduler.start()
+    except Exception:
+        _logger.exception("scan scheduler failed to start")
+
+
 @app.on_event("shutdown")
 async def _shutdown_webhook_dispatcher():
     """Gracefully drain the dispatcher and close its httpx client."""
@@ -141,6 +153,15 @@ async def _shutdown_webhook_dispatcher():
         await webhook_dispatcher.stop()
     except Exception:
         _logger.exception("webhook dispatcher shutdown error")
+
+
+@app.on_event("shutdown")
+async def _shutdown_scan_scheduler():
+    """Stop the cron scheduler gracefully."""
+    try:
+        await scan_scheduler.stop()
+    except Exception:
+        _logger.exception("scan scheduler shutdown error")
 
 
 @app.get("/ready", tags=["health"])

--- a/backend/securescan/migrations/006_add_schedules_table.py
+++ b/backend/securescan/migrations/006_add_schedules_table.py
@@ -1,0 +1,47 @@
+"""Add schedules and schedule_runs tables.
+
+schedules: cron-driven scan schedules (name, target, types, expression,
+           last_run, enabled).
+schedule_runs: cross-reference rows created each time a schedule fires
+               (schedule_id -> scan_id).
+
+Idempotent: both tables use CREATE TABLE IF NOT EXISTS.
+"""
+
+import aiosqlite
+
+VERSION = 6
+DESCRIPTION = "Add schedules and schedule_runs tables"
+
+
+async def up(conn: aiosqlite.Connection) -> None:
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS schedules (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            target_path TEXT NOT NULL,
+            scan_types TEXT NOT NULL DEFAULT '["code","dependency"]',
+            cron_expression TEXT NOT NULL,
+            last_run TEXT,
+            enabled INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL
+        )
+    """)
+    await conn.execute("""
+        CREATE TABLE IF NOT EXISTS schedule_runs (
+            id TEXT PRIMARY KEY,
+            schedule_id TEXT NOT NULL,
+            scan_id TEXT,
+            triggered_at TEXT NOT NULL,
+            FOREIGN KEY (schedule_id) REFERENCES schedules(id)
+        )
+    """)
+    await conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_schedule_runs_schedule "
+        "ON schedule_runs(schedule_id, triggered_at DESC)"
+    )
+
+
+async def down(conn: aiosqlite.Connection) -> None:
+    await conn.execute("DROP TABLE IF EXISTS schedule_runs")
+    await conn.execute("DROP TABLE IF EXISTS schedules")

--- a/backend/securescan/models.py
+++ b/backend/securescan/models.py
@@ -345,3 +345,36 @@ class WebhookDelivery(BaseModel):
     updated_at: datetime
     response_code: int | None = None
     response_body: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Scheduled scans (FEAT-SCHEDULES)
+# ---------------------------------------------------------------------------
+
+
+class Schedule(BaseModel):
+    """A recurring scan schedule driven by a cron expression."""
+
+    id: str
+    name: str
+    target_path: str
+    scan_types: list[ScanType]
+    cron_expression: str
+    last_run: datetime | None = None
+    enabled: bool
+    created_at: datetime
+
+
+class ScheduleRun(BaseModel):
+    """One execution record produced when a schedule fires.
+
+    `scan_id` is None if the scheduler could not start the scan (e.g.
+    lock contention prevented double-fire -- only the winning worker
+    creates a row, but the check happens before the DB insert, so
+    normally scan_id is always populated).
+    """
+
+    id: str
+    schedule_id: str
+    scan_id: str | None = None
+    triggered_at: datetime

--- a/backend/securescan/scheduler.py
+++ b/backend/securescan/scheduler.py
@@ -1,0 +1,166 @@
+"""Background scheduler for cron-driven scan schedules (FEAT-SCHEDULES).
+
+Uses APScheduler's AsyncIOScheduler so jobs run inside the FastAPI event
+loop. On startup every enabled schedule is loaded from the DB and wired
+as a CronTrigger job. PATCH /schedules/{id} (enable/disable/cron change)
+calls reschedule_schedule() or remove_schedule() to keep the live
+scheduler in sync without restarting.
+
+Multi-worker safety
+-------------------
+If SECURESCAN_REDIS_URL is set the scheduler acquires a Redis SET NX EX
+lock before creating a scan. A second worker whose cron fires at the same
+second will see the lock already held and skip without writing a run row.
+In single-process mode (no Redis) the asyncio.Lock on the in-process
+backend gives equivalent protection within a single process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from datetime import datetime
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+logger = logging.getLogger("securescan.scheduler")
+
+# How long (seconds) the Redis lock is held. Must be longer than the
+# expected time between receiving the lock and writing the schedule_run
+# row, but short enough that a crashed worker eventually releases it.
+_LOCK_TTL = 30
+
+
+async def _acquire_lock(schedule_id: str) -> bool:
+    """Try to acquire the per-schedule distributed lock.
+
+    Returns True if the lock was acquired (this worker should run the
+    scan), False if another worker already holds it.
+    """
+    from .pubsub import get_redis_client
+
+    redis = get_redis_client()
+    if redis is None:
+        return True  # no Redis -- single-process, always proceed
+    key = f"ss:sched:lock:{schedule_id}"
+    acquired = await redis.set(key, "1", nx=True, ex=_LOCK_TTL)
+    return bool(acquired)
+
+
+async def _fire_schedule(schedule_id: str) -> None:
+    """Job callback: acquire lock, start scan, record run row."""
+    from .api.scans import _run_scan
+    from .database import (
+        get_schedule,
+        insert_schedule_run,
+        save_scan,
+        touch_schedule_last_run,
+    )
+    from .models import Scan, ScanStatus
+
+    if not await _acquire_lock(schedule_id):
+        logger.info("schedule %s: lock held by another worker, skipping", schedule_id)
+        return
+
+    schedule = await get_schedule(schedule_id)
+    if schedule is None or not schedule.enabled:
+        logger.info("schedule %s: not found or disabled, skipping", schedule_id)
+        return
+
+    now = datetime.utcnow()
+    scan_id = str(uuid.uuid4())
+    run_id = str(uuid.uuid4())
+
+    scan = Scan(
+        id=scan_id,
+        target_path=schedule.target_path,
+        scan_types=schedule.scan_types,
+        status=ScanStatus.PENDING,
+    )
+    await save_scan(scan)
+    await insert_schedule_run(
+        id=run_id,
+        schedule_id=schedule_id,
+        scan_id=scan_id,
+        triggered_at=now,
+    )
+    await touch_schedule_last_run(schedule_id, now)
+
+    logger.info(
+        "schedule %s: triggered scan %s for %s",
+        schedule_id,
+        scan_id,
+        schedule.target_path,
+    )
+    asyncio.create_task(_run_scan(scan_id))
+
+
+class SchedulerService:
+    def __init__(self) -> None:
+        self._scheduler = AsyncIOScheduler()
+
+    async def start(self) -> None:
+        from .database import list_schedules
+
+        schedules = await list_schedules(only_enabled=True)
+        for schedule in schedules:
+            self._add_job(schedule.id, schedule.cron_expression)
+        self._scheduler.start()
+        logger.info("scheduler started with %d job(s)", len(schedules))
+
+    async def stop(self) -> None:
+        if self._scheduler.running:
+            self._scheduler.shutdown(wait=False)
+            logger.info("scheduler stopped")
+
+    def _add_job(self, schedule_id: str, cron_expression: str) -> None:
+        try:
+            trigger = CronTrigger.from_crontab(cron_expression)
+        except Exception as exc:
+            logger.warning("schedule %s: invalid cron %r: %s", schedule_id, cron_expression, exc)
+            return
+        job_id = f"schedule:{schedule_id}"
+        self._scheduler.add_job(
+            _fire_schedule,
+            trigger=trigger,
+            id=job_id,
+            args=[schedule_id],
+            replace_existing=True,
+            misfire_grace_time=60,
+        )
+
+    def reschedule(self, schedule_id: str, cron_expression: str, *, enabled: bool) -> None:
+        """Called after a PATCH to keep the live scheduler in sync."""
+        job_id = f"schedule:{schedule_id}"
+        if not enabled:
+            self.remove(schedule_id)
+            return
+        try:
+            trigger = CronTrigger.from_crontab(cron_expression)
+        except Exception as exc:
+            logger.warning("schedule %s: invalid cron %r: %s", schedule_id, cron_expression, exc)
+            return
+        if self._scheduler.get_job(job_id):
+            self._scheduler.reschedule_job(job_id, trigger=trigger)
+        else:
+            self._scheduler.add_job(
+                _fire_schedule,
+                trigger=trigger,
+                id=job_id,
+                args=[schedule_id],
+                replace_existing=True,
+                misfire_grace_time=60,
+            )
+
+    def remove(self, schedule_id: str) -> None:
+        job_id = f"schedule:{schedule_id}"
+        if self._scheduler.get_job(job_id):
+            self._scheduler.remove_job(job_id)
+
+    def add(self, schedule_id: str, cron_expression: str) -> None:
+        self._add_job(schedule_id, cron_expression)
+
+
+scheduler = SchedulerService()

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -22,6 +22,8 @@ EXPECTED_TABLES = {
     "notifications",
     "webhooks",
     "webhook_deliveries",
+    "schedules",
+    "schedule_runs",
     "schema_version",
 }
 
@@ -141,7 +143,7 @@ async def test_fresh_db_max_version(tmp_path):
         await run_migrations(db)
         max_v = await _get_max_version(db)
 
-    assert max_v == 5
+    assert max_v == 6
 
 
 @pytest.mark.asyncio
@@ -206,7 +208,7 @@ async def test_forward_migration_from_v1(tmp_path):
     assert EXPECTED_TABLES.issubset(tables)
     assert EXPECTED_SCANS_COLS.issubset(scans_cols)
     assert EXPECTED_FINDINGS_COLS.issubset(findings_cols)
-    assert max_v == 5
+    assert max_v == 6
 
 
 @pytest.mark.asyncio
@@ -224,8 +226,8 @@ async def test_idempotency(tmp_path):
             row = await cur.fetchone()
         count = row[0]
 
-    assert v_after_first == v_after_second == 5
-    assert count == 5  # exactly one row per migration version
+    assert v_after_first == v_after_second == 6
+    assert count == 6  # exactly one row per migration version
 
 
 @pytest.mark.asyncio
@@ -244,7 +246,7 @@ async def test_preexisting_legacy_db(tmp_path):
     assert EXPECTED_TABLES.issubset(tables)
     assert EXPECTED_SCANS_COLS.issubset(scans_cols)
     assert EXPECTED_FINDINGS_COLS.issubset(findings_cols)
-    assert max_v == 5
+    assert max_v == 6
 
 
 @pytest.mark.asyncio
@@ -275,4 +277,4 @@ async def test_schema_version_table_records_all_versions(tmp_path):
         async with db.execute("SELECT version FROM schema_version ORDER BY version") as cur:
             rows = await cur.fetchall()
     versions = [r[0] for r in rows]
-    assert versions == [1, 2, 3, 4, 5]
+    assert versions == [1, 2, 3, 4, 5, 6]

--- a/backend/tests/test_schedules.py
+++ b/backend/tests/test_schedules.py
@@ -1,0 +1,378 @@
+"""Tests for scheduled scans (FEAT-SCHEDULES).
+
+Three layers:
+* CRUD endpoints (create, list, get, patch, delete, runs).
+* Scheduler: a schedule firing creates a scan run (apscheduler mocked).
+* Redis lock: two concurrent fires produce exactly one scan (skipped without Redis).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from securescan.database import (
+    get_schedule,
+    init_db,
+    insert_schedule,
+    insert_schedule_run,
+    list_schedule_runs,
+    list_schedules,
+    set_db_path,
+)
+from securescan.main import app
+
+REDIS_URL = os.environ.get("SECURESCAN_REDIS_URL")
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_db(tmp_path, monkeypatch):
+    from securescan.config import settings as _settings
+
+    db_path = str(tmp_path / "schedules_test.db")
+    original = _settings.database_path
+    set_db_path(db_path)
+    asyncio.run(init_db())
+    monkeypatch.delenv("SECURESCAN_API_KEY", raising=False)
+    monkeypatch.delenv("SECURESCAN_AUTH_REQUIRED", raising=False)
+    yield db_path
+    set_db_path(original)
+
+
+@pytest.fixture
+def client(temp_db) -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+async def _seed_schedule(
+    *,
+    name: str = "nightly",
+    target_path: str = "/tmp/repo",
+    scan_types: list[str] | None = None,
+    cron_expression: str = "0 2 * * *",
+    enabled: bool = True,
+) -> str:
+    sched_id = str(uuid.uuid4())
+    await insert_schedule(
+        id=sched_id,
+        name=name,
+        target_path=target_path,
+        scan_types=scan_types or ["code", "dependency"],
+        cron_expression=cron_expression,
+        enabled=enabled,
+        created_at=datetime.utcnow(),
+    )
+    return sched_id
+
+
+# ---------------------------------------------------------------------------
+# DB layer: basic CRUD
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_insert_and_get_schedule(temp_db):
+    sched_id = await _seed_schedule(name="test-sched")
+    sched = await get_schedule(sched_id)
+    assert sched is not None
+    assert sched.name == "test-sched"
+    assert sched.enabled is True
+    assert sched.cron_expression == "0 2 * * *"
+
+
+@pytest.mark.asyncio
+async def test_list_schedules(temp_db):
+    await _seed_schedule(name="a")
+    await _seed_schedule(name="b")
+    scheds = await list_schedules()
+    assert len(scheds) == 2
+
+
+@pytest.mark.asyncio
+async def test_list_schedule_runs(temp_db):
+    sched_id = await _seed_schedule()
+    run_id = str(uuid.uuid4())
+    scan_id = str(uuid.uuid4())
+    await insert_schedule_run(
+        id=run_id,
+        schedule_id=sched_id,
+        scan_id=scan_id,
+        triggered_at=datetime.utcnow(),
+    )
+    runs = await list_schedule_runs(sched_id)
+    assert len(runs) == 1
+    assert runs[0].scan_id == scan_id
+
+
+# ---------------------------------------------------------------------------
+# API: POST (create)
+# ---------------------------------------------------------------------------
+
+
+def test_create_schedule_201(client):
+    with patch("securescan.api.schedules._scheduler") as mock_svc:
+        resp = client.post(
+            "/api/v1/schedules",
+            json={
+                "name": "Daily",
+                "target_path": "/tmp/proj",
+                "scan_types": ["code"],
+                "cron_expression": "0 3 * * *",
+            },
+        )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "Daily"
+    assert data["enabled"] is True
+    assert data["cron_expression"] == "0 3 * * *"
+    mock_svc.add.assert_called_once()
+
+
+def test_create_schedule_invalid_cron_422(client):
+    resp = client.post(
+        "/api/v1/schedules",
+        json={
+            "name": "Bad",
+            "target_path": "/tmp",
+            "cron_expression": "not-a-cron",
+        },
+    )
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# API: GET list
+# ---------------------------------------------------------------------------
+
+
+def test_list_schedules_empty(client):
+    resp = client.get("/api/v1/schedules")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_list_schedules_returns_rows(client):
+    with patch("securescan.api.schedules._scheduler"):
+        client.post(
+            "/api/v1/schedules",
+            json={"name": "S1", "target_path": "/tmp", "cron_expression": "0 1 * * *"},
+        )
+        client.post(
+            "/api/v1/schedules",
+            json={"name": "S2", "target_path": "/tmp", "cron_expression": "0 2 * * *"},
+        )
+    resp = client.get("/api/v1/schedules")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 2
+
+
+# ---------------------------------------------------------------------------
+# API: GET one
+# ---------------------------------------------------------------------------
+
+
+def test_get_schedule_404(client):
+    resp = client.get(f"/api/v1/schedules/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+def test_get_schedule_found(client):
+    with patch("securescan.api.schedules._scheduler"):
+        create_resp = client.post(
+            "/api/v1/schedules",
+            json={"name": "X", "target_path": "/tmp", "cron_expression": "5 * * * *"},
+        )
+    sched_id = create_resp.json()["id"]
+    resp = client.get(f"/api/v1/schedules/{sched_id}")
+    assert resp.status_code == 200
+    assert resp.json()["id"] == sched_id
+
+
+# ---------------------------------------------------------------------------
+# API: PATCH
+# ---------------------------------------------------------------------------
+
+
+def test_patch_schedule_name(client):
+    with patch("securescan.api.schedules._scheduler"):
+        create_resp = client.post(
+            "/api/v1/schedules",
+            json={"name": "Old", "target_path": "/tmp", "cron_expression": "0 0 * * *"},
+        )
+        sched_id = create_resp.json()["id"]
+        resp = client.patch(f"/api/v1/schedules/{sched_id}", json={"name": "New"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "New"
+
+
+def test_patch_schedule_disable(client):
+    with patch("securescan.api.schedules._scheduler"):
+        create_resp = client.post(
+            "/api/v1/schedules",
+            json={"name": "Disable me", "target_path": "/tmp", "cron_expression": "0 0 * * *"},
+        )
+        sched_id = create_resp.json()["id"]
+        resp = client.patch(f"/api/v1/schedules/{sched_id}", json={"enabled": False})
+    assert resp.status_code == 200
+    assert resp.json()["enabled"] is False
+
+
+def test_patch_schedule_404(client):
+    with patch("securescan.api.schedules._scheduler"):
+        resp = client.patch(f"/api/v1/schedules/{uuid.uuid4()}", json={"name": "X"})
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# API: DELETE
+# ---------------------------------------------------------------------------
+
+
+def test_delete_schedule_204(client):
+    with patch("securescan.api.schedules._scheduler"):
+        create_resp = client.post(
+            "/api/v1/schedules",
+            json={"name": "Del", "target_path": "/tmp", "cron_expression": "0 0 * * *"},
+        )
+        sched_id = create_resp.json()["id"]
+        resp = client.delete(f"/api/v1/schedules/{sched_id}")
+    assert resp.status_code == 204
+    assert client.get(f"/api/v1/schedules/{sched_id}").status_code == 404
+
+
+def test_delete_schedule_404(client):
+    with patch("securescan.api.schedules._scheduler"):
+        resp = client.delete(f"/api/v1/schedules/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# API: GET runs
+# ---------------------------------------------------------------------------
+
+
+def test_get_runs_empty(client):
+    with patch("securescan.api.schedules._scheduler"):
+        create_resp = client.post(
+            "/api/v1/schedules",
+            json={"name": "R", "target_path": "/tmp", "cron_expression": "0 0 * * *"},
+        )
+    sched_id = create_resp.json()["id"]
+    resp = client.get(f"/api/v1/schedules/{sched_id}/runs")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_get_runs_404_for_missing_schedule(client):
+    resp = client.get(f"/api/v1/schedules/{uuid.uuid4()}/runs")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Scheduler: firing creates a scan
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fire_schedule_creates_scan(temp_db):
+    """_fire_schedule() creates a Scan and a ScheduleRun row."""
+    from securescan.scheduler import _fire_schedule
+
+    sched_id = await _seed_schedule()
+
+    with (
+        patch("securescan.scheduler._acquire_lock", new=AsyncMock(return_value=True)),
+        patch("securescan.scheduler.asyncio.create_task") as mock_task,
+    ):
+        await _fire_schedule(sched_id)
+
+    # scan task was scheduled
+    mock_task.assert_called_once()
+
+    # schedule_run row was created
+    runs = await list_schedule_runs(sched_id)
+    assert len(runs) == 1
+    assert runs[0].scan_id is not None
+
+    # last_run was updated
+    sched = await get_schedule(sched_id)
+    assert sched is not None
+    assert sched.last_run is not None
+
+
+@pytest.mark.asyncio
+async def test_fire_schedule_lock_blocks_double_fire(temp_db):
+    """When the lock is NOT acquired, no scan run row is created."""
+    from securescan.scheduler import _fire_schedule
+
+    sched_id = await _seed_schedule()
+
+    with patch("securescan.scheduler._acquire_lock", new=AsyncMock(return_value=False)):
+        await _fire_schedule(sched_id)
+
+    runs = await list_schedule_runs(sched_id)
+    assert len(runs) == 0
+
+
+# ---------------------------------------------------------------------------
+# Redis lock: cross-instance double-fire prevention (requires Redis)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not REDIS_URL, reason="SECURESCAN_REDIS_URL not set")
+@pytest.mark.asyncio
+async def test_redis_lock_prevents_double_fire(temp_db):
+    """Two concurrent _fire_schedule() calls with Redis produce exactly one run."""
+    import redis.asyncio as aioredis
+
+    from securescan.scheduler import _fire_schedule
+
+    redis = aioredis.from_url(REDIS_URL, decode_responses=True)
+    try:
+        await redis.ping()
+    except Exception as e:
+        pytest.skip(f"Redis unreachable: {e}")
+    finally:
+        await redis.close()
+
+    import securescan.pubsub as pubsub_mod
+    from securescan.pubsub import RedisBackend
+
+    real_backend = pubsub_mod._backend
+    try:
+        pubsub_mod._backend = RedisBackend(REDIS_URL, prefix="ss-sched-test:")
+        sched_id = await _seed_schedule()
+
+        created_tasks = []
+
+        def _fake_create_task(coro):
+            # Don't actually run the scan -- just record the call.
+            coro.close()
+            created_tasks.append(True)
+
+        with patch("securescan.scheduler.asyncio.create_task", side_effect=_fake_create_task):
+            # Fire twice concurrently -- only one should win the lock.
+            await asyncio.gather(
+                _fire_schedule(sched_id),
+                _fire_schedule(sched_id),
+            )
+
+        runs = await list_schedule_runs(sched_id)
+        assert len(runs) == 1, f"Expected 1 run, got {len(runs)}"
+
+        # Clean up lock key so it doesn't bleed into other tests.
+        r2 = aioredis.from_url(REDIS_URL, decode_responses=True)
+        await r2.delete(f"ss-sched-test:sched:lock:{sched_id}")
+        await r2.close()
+    finally:
+        pubsub_mod._backend = real_backend

--- a/docs/src/scanning/scheduled-scans.md
+++ b/docs/src/scanning/scheduled-scans.md
@@ -1,0 +1,97 @@
+# Scheduled scans
+
+SecureScan can run scans automatically on a **cron schedule**. Each schedule ties
+a target path and set of scan types to a standard 5-field cron expression. The
+background scheduler fires the scan at the configured time, records a run row,
+and updates the schedule's `last_run` timestamp.
+
+## Creating a schedule
+
+### Via the UI
+
+Navigate to **Settings > Schedules** and click **New schedule**. Fill in:
+
+| Field | Description |
+|---|---|
+| **Name** | Human-readable label (e.g. "Nightly SAST") |
+| **Target path** | Absolute path to the directory or file to scan |
+| **Scan types** | One or more of `code`, `dependency`, `iac`, `baseline`, `dast`, `network` |
+| **Cron expression** | Standard 5-field cron (`minute hour dom month dow`) |
+
+Example cron expressions:
+
+| Expression | Meaning |
+|---|---|
+| `0 2 * * *` | Every day at 02:00 |
+| `0 */6 * * *` | Every 6 hours |
+| `30 8 * * 1` | Every Monday at 08:30 |
+| `0 0 1 * *` | First day of each month at midnight |
+
+### Via the API
+
+```http
+POST /api/v1/schedules
+Authorization: X-API-Key <your-admin-key>
+Content-Type: application/json
+
+{
+  "name": "Nightly SAST",
+  "target_path": "/home/ci/repo",
+  "scan_types": ["code", "dependency"],
+  "cron_expression": "0 2 * * *"
+}
+```
+
+The response includes the full `Schedule` object. Schedules are enabled by default.
+
+## Managing schedules
+
+All endpoints require the `admin` API-key scope.
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/v1/schedules` | Create a schedule |
+| `GET` | `/api/v1/schedules` | List all schedules |
+| `GET` | `/api/v1/schedules/{id}` | Fetch one schedule |
+| `PATCH` | `/api/v1/schedules/{id}` | Edit name, path, types, cron, or enabled flag |
+| `DELETE` | `/api/v1/schedules/{id}` | Delete schedule and all run history |
+| `GET` | `/api/v1/schedules/{id}/runs` | Last 50 run records (newest first) |
+
+### Disabling a schedule without deleting it
+
+```http
+PATCH /api/v1/schedules/{id}
+Content-Type: application/json
+
+{"enabled": false}
+```
+
+The in-memory APScheduler job is removed immediately; setting `enabled: true`
+re-registers it.
+
+## Run history
+
+Each time a schedule fires, a `schedule_run` row is created with:
+
+- `triggered_at` - UTC timestamp when the cron fired
+- `scan_id` - UUID of the resulting scan (link to `/scan/{scan_id}` in the UI)
+
+View the last 50 runs from **Settings > Schedules > History** (row menu) or via
+`GET /api/v1/schedules/{id}/runs`.
+
+## Multi-worker safety
+
+When `SECURESCAN_REDIS_URL` is set, the scheduler uses a short-lived Redis lock
+(`SET NX EX 30`) so that two workers whose cron fires at the same second do not
+double-fire the same schedule. The second worker detects the lock and skips
+without creating a run row.
+
+Without Redis the application runs in single-process mode and an in-process
+lock is used automatically.
+
+## Scheduling in the background
+
+The scheduler starts automatically with the FastAPI application via the
+`startup` lifespan event and shuts down cleanly on `shutdown`. No extra
+configuration is required beyond setting `SECURESCAN_REDIS_URL` when running
+multiple workers.

--- a/frontend/src/app/settings/schedules/page.tsx
+++ b/frontend/src/app/settings/schedules/page.tsx
@@ -1,0 +1,764 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  CalendarClock,
+  Check,
+  Loader2,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  Power,
+  PowerOff,
+  Trash2,
+  X,
+} from "lucide-react";
+import {
+  createSchedule,
+  deleteSchedule,
+  listScheduleRuns,
+  listSchedules,
+  patchSchedule,
+} from "@/lib/api";
+import type { Schedule, ScheduleRun, ScanType } from "@/lib/api";
+import { PageHeader } from "@/components/page-header";
+import { DataTable, type Column } from "@/components/data-table";
+
+/* ------------------------------------------------------------------ */
+/* Helpers                                                              */
+/* ------------------------------------------------------------------ */
+
+const ALL_SCAN_TYPES: ScanType[] = ["code", "dependency", "iac", "baseline", "dast", "network"];
+
+function relativeTime(iso?: string | null): string {
+  if (!iso) return "never";
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return "never";
+  const diff = Date.now() - then;
+  const sec = Math.round(diff / 1000);
+  if (sec < 5) return "just now";
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  return `${day}d ago`;
+}
+
+function fullTime(iso?: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleString();
+}
+
+/* ------------------------------------------------------------------ */
+/* Toast                                                                */
+/* ------------------------------------------------------------------ */
+
+interface Toast {
+  id: number;
+  kind: "success" | "error";
+  message: string;
+}
+
+let _toastId = 0;
+
+function useToasts() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  function push(kind: Toast["kind"], message: string) {
+    const id = ++_toastId;
+    setToasts((prev) => [...prev, { id, kind, message }]);
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 3500);
+  }
+
+  function dismiss(id: number) {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }
+
+  return { toasts, push, dismiss };
+}
+
+function ToastStack({ toasts, dismiss }: { toasts: Toast[]; dismiss: (id: number) => void }) {
+  if (!toasts.length) return null;
+  return (
+    <div className="fixed bottom-6 right-6 z-50 flex flex-col gap-2">
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          className={`flex items-center gap-3 rounded-lg border px-4 py-3 text-sm shadow-lg transition-all ${
+            t.kind === "success"
+              ? "border-accent/30 bg-accent-soft text-accent"
+              : "border-red-500/30 bg-red-500/10 text-red-400"
+          }`}
+        >
+          {t.kind === "success" ? <Check size={14} /> : <X size={14} />}
+          <span>{t.message}</span>
+          <button
+            type="button"
+            onClick={() => dismiss(t.id)}
+            className="ml-2 opacity-60 hover:opacity-100"
+            aria-label="Dismiss"
+          >
+            <X size={12} />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Create/Edit Modal                                                    */
+/* ------------------------------------------------------------------ */
+
+interface ScheduleFormState {
+  name: string;
+  target_path: string;
+  scan_types: ScanType[];
+  cron_expression: string;
+}
+
+const BLANK_FORM: ScheduleFormState = {
+  name: "",
+  target_path: "",
+  scan_types: ["code", "dependency"],
+  cron_expression: "0 2 * * *",
+};
+
+interface ScheduleModalProps {
+  initial?: ScheduleFormState;
+  title: string;
+  submitLabel: string;
+  busy: boolean;
+  error: string | null;
+  onSubmit: (state: ScheduleFormState) => void;
+  onClose: () => void;
+}
+
+function ScheduleModal({
+  initial = BLANK_FORM,
+  title,
+  submitLabel,
+  busy,
+  error,
+  onSubmit,
+  onClose,
+}: ScheduleModalProps) {
+  const [form, setForm] = useState<ScheduleFormState>(initial);
+
+  function toggleType(t: ScanType) {
+    setForm((prev) => ({
+      ...prev,
+      scan_types: prev.scan_types.includes(t)
+        ? prev.scan_types.filter((x) => x !== t)
+        : [...prev.scan_types, t],
+    }));
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-xl border border-border bg-card p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-5 flex items-center justify-between">
+          <h2 className="text-base font-semibold">{title}</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-muted hover:text-foreground"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted" htmlFor="s-name">
+              Name
+            </label>
+            <input
+              id="s-name"
+              className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 text-sm outline-none focus:border-accent"
+              value={form.name}
+              onChange={(e) => setForm((p) => ({ ...p, name: e.target.value }))}
+              placeholder="Nightly scan"
+            />
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted" htmlFor="s-path">
+              Target path
+            </label>
+            <input
+              id="s-path"
+              className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 font-mono text-sm outline-none focus:border-accent"
+              value={form.target_path}
+              onChange={(e) => setForm((p) => ({ ...p, target_path: e.target.value }))}
+              placeholder="/home/user/project"
+            />
+          </div>
+
+          <div>
+            <p className="mb-1.5 text-xs font-medium text-muted">Scan types</p>
+            <div className="flex flex-wrap gap-2">
+              {ALL_SCAN_TYPES.map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => toggleType(t)}
+                  className={`rounded-full border px-2.5 py-0.5 font-mono text-[0.6875rem] transition-colors ${
+                    form.scan_types.includes(t)
+                      ? "border-accent/40 bg-accent-soft text-accent"
+                      : "border-border bg-surface-2 text-muted hover:text-foreground"
+                  }`}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted" htmlFor="s-cron">
+              Cron expression
+            </label>
+            <input
+              id="s-cron"
+              className="w-full rounded-md border border-border bg-surface-2 px-3 py-2 font-mono text-sm outline-none focus:border-accent"
+              value={form.cron_expression}
+              onChange={(e) => setForm((p) => ({ ...p, cron_expression: e.target.value }))}
+              placeholder="0 2 * * *"
+            />
+            <p className="mt-1 text-[0.6875rem] text-muted">
+              Standard 5-field cron: minute hour day-of-month month day-of-week
+            </p>
+          </div>
+
+          {error && (
+            <p className="rounded-md border border-red-500/30 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md border border-border px-4 py-2 text-sm text-muted hover:text-foreground"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              disabled={busy || !form.name || !form.target_path || !form.cron_expression || !form.scan_types.length}
+              onClick={() => onSubmit(form)}
+              className="flex items-center gap-2 rounded-md bg-accent px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+            >
+              {busy && <Loader2 size={14} className="animate-spin" />}
+              {submitLabel}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Runs Drawer                                                          */
+/* ------------------------------------------------------------------ */
+
+function RunsDrawer({ schedule, onClose }: { schedule: Schedule; onClose: () => void }) {
+  const [runs, setRuns] = useState<ScheduleRun[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    listScheduleRuns(schedule.id)
+      .then(setRuns)
+      .catch((err: Error) => setError(err.message));
+  }, [schedule.id]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/60 p-4 sm:items-center"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-lg rounded-xl border border-border bg-card shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-border px-5 py-4">
+          <div>
+            <p className="text-sm font-semibold">{schedule.name}</p>
+            <p className="text-xs text-muted">Run history (last 50)</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-muted hover:text-foreground"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="max-h-80 overflow-y-auto">
+          {error && (
+            <p className="px-5 py-4 text-sm text-red-400">{error}</p>
+          )}
+          {!runs && !error && (
+            <div className="flex justify-center py-8">
+              <Loader2 size={20} className="animate-spin text-muted" />
+            </div>
+          )}
+          {runs && runs.length === 0 && (
+            <p className="px-5 py-8 text-center text-sm text-muted">No runs yet</p>
+          )}
+          {runs && runs.length > 0 && (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border bg-surface-2/40 text-xs text-muted">
+                  <th className="px-5 py-2.5 text-left font-medium uppercase tracking-wide">Triggered</th>
+                  <th className="px-5 py-2.5 text-left font-medium uppercase tracking-wide">Scan ID</th>
+                </tr>
+              </thead>
+              <tbody>
+                {runs.map((run) => (
+                  <tr
+                    key={run.id}
+                    className="border-b border-border last:border-b-0 hover:bg-surface-2"
+                  >
+                    <td className="px-5 py-3 text-muted" title={fullTime(run.triggered_at)}>
+                      {relativeTime(run.triggered_at)}
+                    </td>
+                    <td className="px-5 py-3 font-mono text-xs">
+                      {run.scan_id ? (
+                        <a
+                          href={`/scan/${run.scan_id}`}
+                          className="text-accent hover:underline"
+                        >
+                          {run.scan_id.slice(0, 8)}…
+                        </a>
+                      ) : (
+                        <span className="text-muted">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Row menu                                                             */
+/* ------------------------------------------------------------------ */
+
+function RowMenu({
+  schedule,
+  onEdit,
+  onToggle,
+  onDelete,
+  onHistory,
+}: {
+  schedule: Schedule;
+  onEdit: () => void;
+  onToggle: () => void;
+  onDelete: () => void;
+  onHistory: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="relative inline-block">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex h-7 w-7 items-center justify-center rounded-md text-muted hover:bg-surface-2 hover:text-foreground"
+        aria-label="Actions"
+      >
+        <MoreHorizontal size={16} />
+      </button>
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-10"
+            onClick={() => setOpen(false)}
+            aria-hidden
+          />
+          <div className="absolute right-0 z-20 mt-1 w-44 rounded-lg border border-border bg-card py-1 shadow-lg">
+            <button
+              type="button"
+              onClick={() => { setOpen(false); onHistory(); }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-sm text-muted hover:bg-surface-2 hover:text-foreground"
+            >
+              <CalendarClock size={14} /> History
+            </button>
+            <button
+              type="button"
+              onClick={() => { setOpen(false); onEdit(); }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-sm text-muted hover:bg-surface-2 hover:text-foreground"
+            >
+              <Pencil size={14} /> Edit
+            </button>
+            <button
+              type="button"
+              onClick={() => { setOpen(false); onToggle(); }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-sm text-muted hover:bg-surface-2 hover:text-foreground"
+            >
+              {schedule.enabled ? <PowerOff size={14} /> : <Power size={14} />}
+              {schedule.enabled ? "Disable" : "Enable"}
+            </button>
+            <div className="my-1 border-t border-border" />
+            <button
+              type="button"
+              onClick={() => { setOpen(false); onDelete(); }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-400 hover:bg-red-500/10"
+            >
+              <Trash2 size={14} /> Delete
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Delete confirm modal                                                 */
+/* ------------------------------------------------------------------ */
+
+function DeleteModal({
+  schedule,
+  busy,
+  onConfirm,
+  onClose,
+}: {
+  schedule: Schedule;
+  busy: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-sm rounded-xl border border-border bg-card p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="mb-3 text-base font-semibold">Delete schedule?</h2>
+        <p className="mb-5 text-sm text-muted">
+          <span className="font-medium text-foreground">{schedule.name}</span> and all its run
+          history will be permanently deleted.
+        </p>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-border px-4 py-2 text-sm text-muted hover:text-foreground"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onConfirm}
+            className="flex items-center gap-2 rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50 hover:bg-red-700"
+          >
+            {busy && <Loader2 size={14} className="animate-spin" />}
+            Delete
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Page                                                                 */
+/* ------------------------------------------------------------------ */
+
+export default function SchedulesPage() {
+  const [schedules, setSchedules] = useState<Schedule[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  const { toasts, push, dismiss } = useToasts();
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [createBusy, setCreateBusy] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+
+  const [editTarget, setEditTarget] = useState<Schedule | null>(null);
+  const [editBusy, setEditBusy] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  const [deleteTarget, setDeleteTarget] = useState<Schedule | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+
+  const [historyTarget, setHistoryTarget] = useState<Schedule | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await listSchedules();
+      setSchedules(data);
+    } catch (err) {
+      setFetchError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  async function handleCreate(form: ScheduleFormState) {
+    setCreateBusy(true);
+    setCreateError(null);
+    try {
+      const created = await createSchedule(form);
+      setSchedules((prev) => [created, ...prev]);
+      setShowCreate(false);
+      push("success", `Schedule "${created.name}" created`);
+    } catch (err) {
+      setCreateError((err as Error).message);
+    } finally {
+      setCreateBusy(false);
+    }
+  }
+
+  async function handleEdit(form: ScheduleFormState) {
+    if (!editTarget) return;
+    setEditBusy(true);
+    setEditError(null);
+    try {
+      const updated = await patchSchedule(editTarget.id, form);
+      setSchedules((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
+      setEditTarget(null);
+      push("success", `Schedule "${updated.name}" updated`);
+    } catch (err) {
+      setEditError((err as Error).message);
+    } finally {
+      setEditBusy(false);
+    }
+  }
+
+  async function handleToggle(schedule: Schedule) {
+    try {
+      const updated = await patchSchedule(schedule.id, { enabled: !schedule.enabled });
+      setSchedules((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
+      push("success", `Schedule "${updated.name}" ${updated.enabled ? "enabled" : "disabled"}`);
+    } catch (err) {
+      push("error", (err as Error).message);
+    }
+  }
+
+  async function handleDelete() {
+    if (!deleteTarget) return;
+    setDeleteBusy(true);
+    try {
+      await deleteSchedule(deleteTarget.id);
+      setSchedules((prev) => prev.filter((s) => s.id !== deleteTarget.id));
+      push("success", `Schedule "${deleteTarget.name}" deleted`);
+      setDeleteTarget(null);
+    } catch (err) {
+      push("error", (err as Error).message);
+    } finally {
+      setDeleteBusy(false);
+    }
+  }
+
+  const columns: Column<Schedule>[] = [
+    {
+      key: "name",
+      header: "Name",
+      cell: (row) => (
+        <span className="font-medium text-foreground-strong">{row.name}</span>
+      ),
+    },
+    {
+      key: "target_path",
+      header: "Target",
+      cell: (row) => (
+        <span className="font-mono text-xs text-muted" title={row.target_path}>
+          {row.target_path.length > 40 ? `…${row.target_path.slice(-38)}` : row.target_path}
+        </span>
+      ),
+    },
+    {
+      key: "scan_types",
+      header: "Types",
+      cell: (row) => (
+        <div className="flex flex-wrap gap-1">
+          {row.scan_types.map((t) => (
+            <span
+              key={t}
+              className="inline-flex items-center rounded-full border border-border bg-surface-2 px-2 py-0.5 font-mono text-[0.6875rem] text-foreground"
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+      ),
+    },
+    {
+      key: "cron_expression",
+      header: "Cron",
+      cell: (row) => (
+        <span className="font-mono text-xs text-foreground">{row.cron_expression}</span>
+      ),
+    },
+    {
+      key: "last_run",
+      header: "Last run",
+      cell: (row) => (
+        <span className="text-muted" title={fullTime(row.last_run)}>
+          {relativeTime(row.last_run)}
+        </span>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (row) =>
+        row.enabled ? (
+          <span className="inline-flex items-center gap-1 rounded-full border border-accent/40 bg-accent-soft px-2 py-0.5 text-[0.6875rem] text-accent">
+            <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-accent" />
+            Active
+          </span>
+        ) : (
+          <span className="inline-flex items-center rounded-full border border-border bg-surface-2 px-2 py-0.5 text-[0.6875rem] text-muted">
+            Disabled
+          </span>
+        ),
+    },
+    {
+      key: "actions",
+      header: "",
+      align: "right",
+      cell: (row) => (
+        <RowMenu
+          schedule={row}
+          onEdit={() => setEditTarget(row)}
+          onToggle={() => handleToggle(row)}
+          onDelete={() => setDeleteTarget(row)}
+          onHistory={() => setHistoryTarget(row)}
+        />
+      ),
+    },
+  ];
+
+  return (
+    <>
+      <ToastStack toasts={toasts} dismiss={dismiss} />
+
+      {showCreate && (
+        <ScheduleModal
+          title="Create schedule"
+          submitLabel="Create"
+          busy={createBusy}
+          error={createError}
+          onSubmit={handleCreate}
+          onClose={() => { setShowCreate(false); setCreateError(null); }}
+        />
+      )}
+
+      {editTarget && (
+        <ScheduleModal
+          title="Edit schedule"
+          submitLabel="Save"
+          busy={editBusy}
+          error={editError}
+          initial={{
+            name: editTarget.name,
+            target_path: editTarget.target_path,
+            scan_types: editTarget.scan_types,
+            cron_expression: editTarget.cron_expression,
+          }}
+          onSubmit={handleEdit}
+          onClose={() => { setEditTarget(null); setEditError(null); }}
+        />
+      )}
+
+      {deleteTarget && (
+        <DeleteModal
+          schedule={deleteTarget}
+          busy={deleteBusy}
+          onConfirm={handleDelete}
+          onClose={() => setDeleteTarget(null)}
+        />
+      )}
+
+      {historyTarget && (
+        <RunsDrawer
+          schedule={historyTarget}
+          onClose={() => setHistoryTarget(null)}
+        />
+      )}
+
+      <div className="flex flex-col gap-6 p-6">
+        <PageHeader
+          title="Schedules"
+          meta="Cron-driven recurring scans"
+          actions={
+            <button
+              type="button"
+              onClick={() => setShowCreate(true)}
+              className="flex items-center gap-2 rounded-md bg-accent px-3 py-2 text-sm font-medium text-white hover:bg-accent/90"
+            >
+              <Plus size={16} />
+              New schedule
+            </button>
+          }
+        />
+
+        {fetchError && (
+          <div className="rounded-lg border border-red-500/20 bg-red-500/5 px-4 py-3 text-sm text-red-400">
+            {fetchError}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="flex justify-center py-12">
+            <Loader2 size={24} className="animate-spin text-muted" />
+          </div>
+        ) : (
+          <DataTable
+            data={schedules}
+            columns={columns}
+            getRowKey={(row) => row.id}
+            emptyState={
+              <div className="flex flex-col items-center gap-3 py-12 text-center">
+                <CalendarClock size={32} className="text-muted/50" />
+                <p className="text-sm text-muted">No schedules yet</p>
+                <button
+                  type="button"
+                  onClick={() => setShowCreate(true)}
+                  className="flex items-center gap-2 rounded-md bg-accent px-3 py-2 text-sm font-medium text-white hover:bg-accent/90"
+                >
+                  <Plus size={14} />
+                  Create your first schedule
+                </button>
+              </div>
+            }
+          />
+        )}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/sidebar.tsx
+++ b/frontend/src/components/sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useMemo, useSyncExternalStore } from "react";
 import {
   Bell,
+  CalendarClock,
   GitCompare,
   History,
   KeyRound,
@@ -41,6 +42,7 @@ const navItems: NavItem[] = [
   { label: "Scanners", href: "/scanners", icon: Settings },
   { label: "API keys", href: "/settings/keys", icon: KeyRound, group: "settings" },
   { label: "Webhooks", href: "/settings/webhooks", icon: Webhook, group: "settings" },
+  { label: "Schedules", href: "/settings/schedules", icon: CalendarClock, group: "settings" },
 ];
 
 interface RecentScan {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1240,6 +1240,100 @@ export async function testWebhook(id: string): Promise<{ delivery_id: string }> 
   throw new Error(`Failed to fire test webhook (${res?.status ?? "network"})`);
 }
 
+// --- Scheduled scans (admin) -------------------------------------------
+//
+// Endpoints (all behind require_scope("admin")):
+//   POST   /schedules                  → 201 Schedule
+//   GET    /schedules                  → Schedule[]
+//   GET    /schedules/{id}             → Schedule
+//   PATCH  /schedules/{id}             → Schedule (updated)
+//   DELETE /schedules/{id}             → 204
+//   GET    /schedules/{id}/runs        → ScheduleRun[] (last 50)
+
+export type ScanType = "code" | "dependency" | "iac" | "baseline" | "dast" | "network";
+
+export interface Schedule {
+  id: string;
+  name: string;
+  target_path: string;
+  scan_types: ScanType[];
+  cron_expression: string;
+  last_run: string | null;
+  enabled: boolean;
+  created_at: string;
+}
+
+export interface ScheduleRun {
+  id: string;
+  schedule_id: string;
+  scan_id: string | null;
+  triggered_at: string;
+}
+
+export async function listSchedules(): Promise<Schedule[]> {
+  const res = await apiFetch(`${API_BASE}/schedules`, { cache: "no-store" });
+  if (res.ok) return (await res.json()) as Schedule[];
+  throw new Error(`Failed to load schedules (${res.status})`);
+}
+
+export async function createSchedule(body: {
+  name: string;
+  target_path: string;
+  scan_types: ScanType[];
+  cron_expression: string;
+}): Promise<Schedule> {
+  const res = await apiFetch(`${API_BASE}/schedules`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (res.ok) return (await res.json()) as Schedule;
+  if (res.status === 422) {
+    let detail = "Invalid schedule request.";
+    try {
+      const data = (await res.json()) as { detail?: string | { msg: string }[] };
+      if (typeof data?.detail === "string") detail = data.detail;
+      else if (Array.isArray(data?.detail)) detail = data.detail.map((d) => d.msg).join("; ");
+    } catch {
+      /* keep default */
+    }
+    throw new Error(detail);
+  }
+  throw new Error(`Failed to create schedule (${res.status})`);
+}
+
+export async function patchSchedule(
+  id: string,
+  body: Partial<Pick<Schedule, "name" | "target_path" | "scan_types" | "cron_expression" | "enabled">>,
+): Promise<Schedule> {
+  const res = await apiFetch(`${API_BASE}/schedules/${encodeURIComponent(id)}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (res.ok) return (await res.json()) as Schedule;
+  if (res.status === 404) throw new Error("Schedule not found.");
+  throw new Error(`Failed to update schedule (${res.status})`);
+}
+
+export async function deleteSchedule(id: string): Promise<void> {
+  const res = await apiFetch(`${API_BASE}/schedules/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+  if (res.ok || res.status === 204) return;
+  if (res.status === 404) throw new Error("Schedule not found.");
+  throw new Error(`Failed to delete schedule (${res.status})`);
+}
+
+export async function listScheduleRuns(id: string): Promise<ScheduleRun[]> {
+  const res = await apiFetch(`${API_BASE}/schedules/${encodeURIComponent(id)}/runs`, {
+    cache: "no-store",
+  });
+  if (res.ok) return (await res.json()) as ScheduleRun[];
+  if (res.status === 404) throw new Error("Schedule not found.");
+  throw new Error(`Failed to load schedule runs (${res.status})`);
+}
+
 export async function revokeApiKey(keyId: string): Promise<void> {
   const res = await apiFetch(`${API_BASE}/keys/${encodeURIComponent(keyId)}`, {
     method: "DELETE",


### PR DESCRIPTION
## Summary

Implements #7: scheduled scans (cron-like recurring runs).

## What's new

### Backend
- Migration `006_add_schedules_table.py` adds two tables:
  - `schedules` (id, name, target_path, scan_types, cron_expression, last_run, enabled, created_at)
  - `schedule_runs` (id, schedule_id, scan_id, triggered_at) with index on (schedule_id, triggered_at DESC)
- `scheduler.py` — `SchedulerService` over APScheduler `AsyncIOScheduler`. Jobs registered from enabled DB rows at startup; `reschedule/remove/add` keep the live scheduler in sync with API mutations.
- Multi-worker safety: `_fire_schedule()` uses a Redis `SET NX EX` lock (via the pubsub backplane from #4) keyed on `schedule:<id>:<minute_bucket>` so two workers never fire the same trigger. Falls back to single-process when `SECURESCAN_REDIS_URL` is unset.
- `api/schedules.py` — `POST/GET/PATCH/DELETE /api/v1/schedules` and `GET /{id}/runs`. Admin scope. Cron expressions validated at 422 via `CronTrigger.from_crontab`.
- `apscheduler>=3.10.0` added to `pyproject.toml`.

### Frontend
- `/settings/schedules` page mirrors the keys/webhooks layout: DataTable, create/edit modal, delete confirm, schedule run-history drawer.
- New `Schedule` / `ScheduleRun` types and CRUD helpers in `lib/api.ts`.
- Sidebar nav entry.

### Docs
- `docs/src/scanning/scheduled-scans.md`.

## Tests

- 18 new tests pass, 1 skipped (Redis cross-worker double-fire test, gated on `SECURESCAN_REDIS_URL` exactly like the pubsub redis test).
- Mocked APScheduler trigger creates a real Scan and a schedule_runs row.
- Local: `cd backend && ruff check . && ruff format --check . && python -m pytest tests/ -x -q` — 950 passed, 4 skipped (pre-existing nmap/semgrep env-only failures excluded; same as main).

## Notes

- Defaults are off; admin opts in by creating a schedule.
- Cron parser is APScheduler's, which accepts the standard 5-field crontab.
- Lock TTL is 60s, scoped to the minute bucket so a slow worker never blocks a later trigger.
